### PR TITLE
Avoid underscores and print URL

### DIFF
--- a/bin/pow
+++ b/bin/pow
@@ -20,6 +20,7 @@ class Pow < Thor
     name ||= File.basename(current_path).tr('_', '-')
     symlink_path = "#{POWPATH}/#{name}"
     FileUtils.ln_s(current_path, symlink_path) unless File.exists?(symlink_path)
+    $stdout.puts "Your application is now available at http://#{name}.dev/"
   end
   
   desc "restart", "restart current pow"


### PR DESCRIPTION
Hi!

I've done two small tweaks to powder:
1. Change underscores in directory names to dashes. If you're in a directory called "my_app" and run `pow`, it will create a link called "my-app". This is to get around the fact that domains can't have underscores in them.
2. Print out URL after linking. When you run `pow link my-app` it will print a message with the URL "http://my-app.dev" to STDOUT, so that you can easily copy and paste it.

Hope you like it!
