### PR TITLE
Add 'log' command to tail development log

### DIFF
--- a/bin/pow
+++ b/bin/pow
@@ -4,6 +4,7 @@ require 'rubygems'
 require 'thor'
 require 'fileutils'
 require "net/https"
+require 'file/tail'
 
 class Pow < Thor
   include Thor::Actions
@@ -57,6 +58,16 @@ class Pow < Thor
   desc "uninstall", "Uninstalls pow"
   def uninstall
     %x{curl get.pow.cx/uninstall.sh | sh}
+  end
+
+  desc "log", "Tails the development log"
+  def log
+    File.open('log/development.log') do |log|
+       log.extend(File::Tail)
+       log.interval = 1
+       log.backward(10)
+       log.tail { |line| puts line }
+     end
   end
 
   private

--- a/powder.gemspec
+++ b/powder.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'thor', '>=0.9.2'
+  s.add_dependency 'file-tail', '>=1.0.5'
 end


### PR DESCRIPTION
Now that I'm not running "rails s", I find myself cd'ing into the app and running "tail -f log/development.log" a lot. Cooked this up to shorten it up.
