### PR TITLE
Updated thor dependency

### DIFF
--- a/powder.gemspec
+++ b/powder.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.executables   = ["powder"]
   s.require_paths = ["lib"]
 
-  s.add_dependency 'thor', '>=0.9.2'
+  s.add_dependency 'thor', '>=0.11.5'
 end


### PR DESCRIPTION
I had 0.9.9 installed at home and the powder cmd failed. This seems to be the earliest version that has Thor::Actions
