### PR TITLE
Powder on/off -- easily enable and disable firewall rules

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -17,18 +17,36 @@ module Powder
     map '-o' => 'open'
     map '-v' => 'version'
 
-    POWPATH = "#{`echo ~`.chomp}/.pow"
+    POW_PATH = "#{ENV['HOME']}/.pow"
+    POW_DAEMON_PLIST_PATH="#{ENV['HOME']}/Library/LaunchAgents/cx.pow.powd.plist"
+    POW_FIREWALL_PLIST_PATH = "/Library/LaunchDaemons/cx.pow.firewall.plist"
 
-    desc "on", "Turn pow on"
-    def on
-      %x[sudo ipfw add fwd 127.0.0.1,20559 tcp from any to me dst-port 80 in]
-      %x[sudo sysctl -w net.inet.ip.forwarding=1]
+    desc "up", "Enable pow"
+    def up
+      if File.exists? POW_FIREWALL_PLIST_PATH
+        %x{sudo launchctl load /Library/LaunchDaemons/cx.pow.firewall.plist}
+      else
+        say "Pow firewall configuration missing."
+      end
     end
 
-    desc "off", "Turn pow off"
-    def off
-      rule = %x[sudo ipfw show | grep 'fwd 127.0.0.1,20559 tcp from any to me dst-port 80 in'].split[0]
-      %x[sudo ipfw delete #{rule} && sudo sysctl -w net.inet.ip.forwarding=0]
+    desc "down", "Disable pow"
+    def down
+      if File.exists? POW_FIREWALL_PLIST_PATH
+        if not %x{sudo launchctl list | grep cx.pow.firewall}.empty?
+          %x{sudo launchctl unload /Library/LaunchDaemons/cx.pow.firewall.plist}
+        end
+        if ports = File.open(POW_FIREWALL_PLIST_PATH).read.match(/fwd .*?,([\d]+).*?dst-port ([\d]+)/)
+          http_port, dst_port = ports[1..2]
+        end
+      end
+      
+      http_port ||= 20559
+      dst_port ||= 80
+      
+      if rule = %x{sudo ipfw show | grep ",#{http_port} .* dst-port #{dst_port} in"}.split.first
+        %x{sudo ipfw delete #{rule} && sudo sysctl -w net.inet.ip.forwarding=0}
+      end
     end
 
     desc "link", "Link a pow"
@@ -36,7 +54,7 @@ module Powder
       return unless is_powable?
       current_path = %x{pwd}.chomp
       name ||= current_dir_pow_name
-      symlink_path = "#{POWPATH}/#{name}"
+      symlink_path = "#{POW_PATH}/#{name}"
       FileUtils.ln_s(current_path, symlink_path) unless File.exists?(symlink_path)
       say "Your application is now available at http://#{name}.#{domain}/"
     end
@@ -50,7 +68,7 @@ module Powder
 
     desc "list", "List current pows"
     def list
-      Dir[POWPATH + "/*"].map { |a| say File.basename(a) }
+      Dir[POW_PATH + "/*"].map { |a| say File.basename(a) }
     end
 
     desc "open", "Open a pow in the browser"
@@ -61,7 +79,7 @@ module Powder
     desc "remove", "Remove a pow"
     def remove(name=nil)
       return unless is_powable?
-      FileUtils.rm_f POWPATH + '/' + (name || current_dir_pow_name)
+      FileUtils.rm_f POW_PATH + '/' + (name || current_dir_pow_name)
     end
 
     desc "install", "Installs pow"


### PR DESCRIPTION
Added `powder on` and `powder off` which add and remove the firewall rules, enabling and disabling pow.

Not necessarily release ready, but an idea that might be nice. It works for me and suits my needs. Sometimes I want to run something else on port 80, like the OS X default Apache 2 install.
