### PR TITLE
Radiant applications can be "powered"

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -103,7 +103,9 @@ module Powder
     end
   
     def is_rails2_app?
-      File.exists?('config/environment.rb') && !`grep RAILS_GEM_VERSION config/environment.rb`.empty?
+      File.exists?('config/environment.rb') && 
+        (!`grep RAILS_GEM_VERSION config/environment.rb`.empty? ||
+         !`grep Radiant::Initializer config/environment.rb`.empty?)
     end
 
     def domain


### PR DESCRIPTION
I've just modified `Powder::CLI#is_rails2_app?` so that it detects applications using [Radiant CMS](https://github.com/radiant/radiant) to generate a config.ru for them.
