### PR TITLE
expand ~/.powconfig to absolute path before detecting its existence

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -177,7 +177,7 @@ module Powder
     end
 
     def domain
-      if File.exists? '~/.powconfig'
+      if File.exists? File.expand_path('~/.powconfig')
         returned_domain = %x{source ~/.powconfig; echo $POW_DOMAINS}.gsub("\n", "").split(",").first
         returned_domain = %x{source ~/.powconfig; echo $POW_DOMAIN}.gsub("\n", "") if returned_domain.nil? || returned_domain.empty?
         returned_domain = 'dev' if returned_domain.nil? || returned_domain.empty?


### PR DESCRIPTION
I have multiple `POW_DOMAINS` set in `~/.powconfig`, and the first one is `local` instead of `dev`. When I `powder open blahapp`, it opens `blahapp.dev` not `blahapp.local` as expected.

Then I use `irb` (REE 1.8.7) to see if `File.exists?` works with `~` prefix, the answer is no.  So here comes a patch which expands `~/.powconfig` path into an absolute one before calling `File.exists?`.

Sincerely,
Yu-Cheng Chuang
