### PR TITLE
Add cleanup command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,9 @@ powder manages [pow](http://pow.cx/)
     $ powder remove bacon
     => Unlink bacon
 
+    $ powder cleanup
+    => remove all invalid symbolic link
+
 ### Working with Pow ###
 
     $ powder applog

--- a/bin/powder
+++ b/bin/powder
@@ -83,6 +83,13 @@ module Powder
       FileUtils.rm_f POW_PATH + '/' + (name || current_dir_pow_name)
     end
 
+    desc "cleanup", "Clean up invalid symbolic link"
+    def cleanup
+      Dir[POW_PATH + "/*"].map { |a| 
+        FileUtils.rm a unless File.exists? File.readlink a
+      }
+    end
+
     desc "install", "Installs pow"
     def install
       %x{curl get.pow.cx | sh}


### PR DESCRIPTION
In case remove the project directory without `powder remove`, invalid symbolic link is left at `~/.pow` directory.
This command wipe it at once.
