### PR TITLE
Add index command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,10 @@ powder manages [pow](http://pow.cx/)
     => List all the current apps linked in ~/.pow
     # aliased as powder -l
 
+    $ powder index
+    => Create index.html to all apps in ~/.pow
+    # ~/.pow/powder_index/public/index.html
+
     $ powder log
     => Tails the pow log.
     # Not the application log, but the pow log, available at

--- a/bin/powder
+++ b/bin/powder
@@ -72,6 +72,17 @@ module Powder
       Dir[POW_PATH + "/*"].map { |a| say File.basename(a) }
     end
 
+    desc "index", "Create index page of Powable apps"
+    def index
+      list = "<ul>"
+      Dir[POW_PATH + "/*"].map { |a| 
+        list << "<li><a href=http://#{File.basename(a)}.dev>#{File.basename(a)}</a></li>" unless File.basename(a) == 'powder_index'
+      }
+      list << "</ul>"
+      FileUtils.mkdir_p("#{POW_PATH}/powder_index/public")
+      create_file "#{POW_PATH}/powder_index/public/index.html", list
+    end
+
     desc "open", "Open a pow in the browser"
     def open(name=nil)
       %x{open http://#{name || current_dir_pow_name}.#{domain}}


### PR DESCRIPTION
Creates `~/.pow/powder-index/public/index`.
Of course, it's visible via Pow and enables to access to all apps links in `~/.pow` easily!
