### PR TITLE
Adjust `powder` and `powder link` behavior

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,19 +9,24 @@ powder manages [pow](http://pow.cx/)
 
 ### Linking apps in Pow ###
 
-    $ powder
-    => Link the current dir_name to ~/.pow/dir-name
-    # if the dir_name has underscores in, powder changes them to hyphens
+    $ powder [-h|help]
+    => Display usage information
+    # Lists name and brief descriptions of the tasks available
 
-    $ powder link bacon
+    $ powder link 
+    => Link the current dir to ~/.pow/<current_directory>
+
+    $ powder link [bacon]
     => Link the current dir to ~/.pow/bacon
-    # If the current directory doesn't look like an app that can be powed
-    # by pow it will offer to download a basic config.ru for Rails 2
+
+    # For both forms of link, if the current directory doesn't 
+    # look like an app that can be powed it will offer to download
+    # a basic config.ru for Rails 2
 
     $ powder remove
     => Unlink current_dir
 
-    $ powder remove bacon
+    $ powder remove [bacon]
     => Unlink bacon
 
 ### Working with Pow ###
@@ -45,7 +50,7 @@ powder manages [pow](http://pow.cx/)
     => Opens the pow link in a browser
     # aliased as powder -o
 
-    $ powder open bacon
+    $ powder open [bacon]
     => Opens http://bacon.dev in a browser
     # if you have set up alternative top level domains in .powconfig,
     # then the first listed domain will be opened.

--- a/bin/powder
+++ b/bin/powder
@@ -9,7 +9,7 @@ require 'powder/version'
 module Powder
   class CLI < Thor
     include Thor::Actions
-    default_task :link
+    default_task :help
 
     map '-r' => 'restart'
     map '-l' => 'list'


### PR DESCRIPTION
Running `powder` with no arguments should display usage information instead linking the current directory.  This is standard behavior for gems that provide CLI functionally.  Otherwise, those who installed the gem without reading the full README on it's usage have to come back here (or find it, if they didn't discover it on Github).  It's also more helpful if you haven't used the gem much, or recently, to see the usage options immediately instead of having to come to the source for the README.

`powder link` should then accept 0 or 1 argument, with 0 arguments linking the current directory just as `powder` alone does now.  `powder link` with 1 argument's behavior would remain unchanged.  

I'd be happy to submit a pull request if you agree.
