### PR TITLE
Use `unlink` to remove an app

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,10 +18,10 @@ powder manages [pow](http://pow.cx/)
     # If the current directory doesn't look like an app that can be powed
     # by pow it will offer to download a basic config.ru for Rails 2
 
-    $ powder remove
+    $ powder unlink 
     => Unlink current_dir
 
-    $ powder remove bacon
+    $ powder unlink bacon
     => Unlink bacon
 
 ### Working with Pow ###

--- a/bin/powder
+++ b/bin/powder
@@ -77,11 +77,15 @@ module Powder
       %x{open http://#{name || current_dir_pow_name}.#{domain}}
     end
 
-    desc "remove", "Remove a pow"
-    def remove(name=nil)
+    desc "unlink", "Unlink a pow app"
+    def unlink(name=nil)
       return unless is_powable?
       FileUtils.rm_f POW_PATH + '/' + (name || current_dir_pow_name)
+      say "Successfully removed #{(name || current_dir_pow_name)}"
     end
+
+    desc "remove", "An alias to Unlink (depreciated)"
+    alias :remove :unlink
 
     desc "install", "Installs pow"
     def install


### PR DESCRIPTION
To be consistent let's use `unlink` to remove an app instead of `remove`.  Set `remove` as a depreciated alias of `unlink` for backwards compatibility, to be discarded in version `0.2` or something
