### PR TITLE
Fix a bug caused by the situation of linking an app before pow is installed

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -53,11 +53,15 @@ module Powder
     desc "link", "Link a pow"
     def link(name=nil)
       return unless is_powable?
-      current_path = %x{pwd}.chomp
-      name ||= current_dir_pow_name
-      symlink_path = "#{POW_PATH}/#{name}"
-      FileUtils.ln_s(current_path, symlink_path) unless File.exists?(symlink_path)
-      say "Your application is now available at http://#{name}.#{domain}/"
+      if File.symlink?(POW_PATH)
+        current_path = %x{pwd}.chomp
+        name ||= current_dir_pow_name
+        symlink_path = "#{POW_PATH}/#{name}"
+        FileUtils.ln_s(current_path, symlink_path) unless File.exists?(symlink_path)
+        say "Your application is now available at http://#{name}.#{domain}/"
+      else
+        say "Pow is not installed."
+      end
     end
 
     desc "restart", "Restart current pow"


### PR DESCRIPTION
Do not link an app if ~/.pow is not a symlink. This is generally caused by pow not yet being installed and it leads to a situation wherein Pow won't recognize your ~/.pow path. The problem is described in this issue on the Pow issue tracker:

https://github.com/37signals/pow/issues/145
