### PR TITLE
Host/Unhost for adding/removing to/from hosts file, solves "Can't access hosts offline".

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -113,6 +113,35 @@ module Powder
        say "powder #{Powder::VERSION}"
     end
     
+    desc "host", "Updates hosts file to map pow domains to 127.0.0.1"
+    def host
+      hosts_file_path = "/etc/hosts"
+      pow_domain_records = Dir[POW_PATH + "/*"].map { |a| "127.0.0.1\t#{File.basename(a)}.#{domain}\t#powder" }
+      hosts_file = File.read("/etc/hosts").split("\n").delete_if {|row| row =~ /.+(#powder)/}
+      first_loopback_index = hosts_file.index {|i| i =~ /^(127.0.0.1).+/}
+      hosts_file = hosts_file.insert(first_loopback_index + 1, pow_domain_records)
+      File.open("#{ENV['HOME']}/hosts-powder", "w")  do
+        |file| file.puts hosts_file.join("\n")
+      end
+      %x{cp #{hosts_file_path} #{ENV['HOME']}/hosts-powder.bak}
+      %x{sudo mv #{ENV['HOME']}/hosts-powder #{hosts_file_path}}
+      %x{dscacheutil -flushcache}
+      say "Domains added to hosts file, old host file is saved at #{ENV['HOME']}/hosts-powder.bak"
+    end
+    
+    desc "unhost", "Removes pow domains from hostfile"
+    def unhost
+      hosts_file_path = "/etc/hosts"
+      hosts_file = File.read("/etc/hosts").split("\n").delete_if {|row| row =~ /.+(#powder)/}
+      File.open("#{ENV['HOME']}/hosts-powder", "w")  do
+        |file| file.puts hosts_file.join("\n")
+      end
+      %x{cp #{hosts_file_path} #{ENV['HOME']}/hosts-powder.bak}
+      %x{sudo mv #{ENV['HOME']}/hosts-powder #{hosts_file_path}}
+      %x{dscacheutil -flushcache}
+      say "Domains removed from hosts file, old host file is saved at #{ENV['HOME']}/hosts-powder.bak"
+    end
+    
     desc "config", "Shows current pow configuration"
     def config
       results = %x{curl --silent -H host:pow localhost/config.json}.gsub(':','=>')


### PR DESCRIPTION
A problem that me and many with me has had with pow is that it uses resolver to map the domains. That is okay as long as you are connected to a network of some sort, but when you disconnect your pow domains dies with the connection. But adding the domains to the hosts file solves this problem, so I added it to the already wonderful powder :)

The solution may not be the most elegant there is, but it works great (at least on my machine). Please pull it and clean it up a bit so it gets baked in to the powder loveliness.

The pow issue ticket for the "Can't access hosts offline" is at: https://github.com/37signals/pow/issues/104 
