### PR TITLE
An asterisk next to the current app in powder list output

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -89,8 +89,9 @@ module Powder
     desc "list", "List current pows"
     def list
       pows = Dir[POW_PATH + "/*"].map do |link|
-        realpath = File.readlink(link).gsub(ENV['HOME'], '~')
-        [File.basename(link), realpath]
+        realpath = File.readlink(link)
+        app_is_current = (realpath == Dir.pwd) ? '*' : ' '
+        [app_is_current, File.basename(link), realpath.gsub(ENV['HOME'], '~')]
       end
       print_table(pows)
     end


### PR DESCRIPTION
Following the discussion in #32 I've added a star near an active application (i.e. a link in `~/.pow` pointing to the current working directory) in `powder list` output, something like this:

``` bash
[~/apps/app2]$ powder list
  app1 ~/apps/app1
* app2 ~/apps/app2
  app3 ~/apps/app3
```
