### PR TITLE
Move helper methods into a module

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -4,8 +4,7 @@ require 'rubygems'
 require 'thor'
 require 'fileutils'
 require 'net/https'
-require 'powder/version'
-require 'powder/helpers'
+require 'powder'
 
 
 module Powder
@@ -120,12 +119,7 @@ module Powder
 
     desc "list", "List current pows"
     def list
-      pows = Dir[POW_PATH + "/*"].map do |link|
-        realpath = File.readlink(link)
-        app_is_current = (realpath == Dir.pwd) ? '*' : ' '
-        [app_is_current, File.basename(link), realpath.gsub(ENV['HOME'], '~')]
-      end
-      print_table(pows)
+      print_table(pow_apps)
     end
 
     desc "open", "Open a pow in the browser"

--- a/lib/powder.rb
+++ b/lib/powder.rb
@@ -1,2 +1,2 @@
-module Powder
-end
+require 'powder/version'
+require 'powder/helpers'

--- a/lib/powder/helpers.rb
+++ b/lib/powder/helpers.rb
@@ -90,5 +90,13 @@ module Powder
         'dev'
       end
     end
+    
+    def pow_apps
+      Dir[POW_PATH + "/*"].map do |link|
+        realpath = File.readlink(link)
+        app_is_current = (realpath == Dir.pwd) ? '*' : ' '
+        [app_is_current, File.basename(link), realpath.gsub(ENV['HOME'], '~')]
+      end
+    end
   end
 end


### PR DESCRIPTION
This extracts all helper methods into a module, wich will allow others to use the Powder gem as a library. Specifically, it will help me with Powser ;) 

Will probably conflict a bit with the other pull request that is out right now... Just let me know if you want me to wait and merge his commits into the module.
