### PR TITLE
Restart pow Process

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -124,7 +124,7 @@ module Powder
     
     desc "respawn", "Restart the pow process"
     def respawn
-      `launchctl stop cx.pow.powd` 
+      %x{launchctl stop cx.pow.powd}
     end
 
     desc "list", "List current pows"


### PR DESCRIPTION
`powder respawn`

Call it when the pow process needs to be killed and restarted, like in this scenario: https://github.com/37signals/pow/issues/99
