### PR TITLE
Pow config and status tasks to use localhost:20559

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -22,6 +22,7 @@ module Powder
 
     POWDER_CONFIG = ".powder"
     POW_PATH = "#{ENV['HOME']}/.pow"
+    POW_CONFIG = "#{ENV['HOME']}/.powconfig"
     POW_DAEMON_PLIST_PATH="#{ENV['HOME']}/Library/LaunchAgents/cx.pow.powd.plist"
     POW_FIREWALL_PLIST_PATH = "/Library/LaunchDaemons/cx.pow.firewall.plist"
 
@@ -225,7 +226,8 @@ module Powder
 
     desc "config", "Shows current pow configuration"
     def config
-      results = %x{curl --silent -H host:pow localhost/config.json}.gsub(':','=>')
+      http_port = ":" + configured_pow_http_port.to_s
+      results = %x{curl --silent -H host:pow localhost#{http_port}/config.json}.gsub(':','=>')
       return say("Error: Cannot get Pow config. Pow may be down. Try 'powder up' first.") if results.empty? || !(results =~ /^\{/)
       json = eval results
       json.each do |k,v|
@@ -240,7 +242,8 @@ module Powder
 
     desc "status", "Shows current pow status"
     def status
-      results = %x{curl --silent -H host:pow localhost/status.json}.gsub(':','=>')
+      http_port = ":" + configured_pow_http_port.to_s
+      results = %x{curl --silent -H host:pow localhost#{http_port}/status.json}.gsub(':','=>')
       return say("Error: Cannot get Pow status. Pow may be down. Try 'powder up' first.") if results.empty? || !(results =~ /^\{/)
       json = eval results
       json.each {|k,v| say "#{k.ljust(12, ' ')} #{v}"}
@@ -261,6 +264,12 @@ module Powder
       end
 
       return nil
+    end
+
+    def configured_pow_http_port
+      return 20559 unless File.exists?(POW_CONFIG)
+
+      return File.open(POW_CONFIG).read.match(/export[\s]+POW_HTTP_PORT[\s]*=[\s]*(\d+)/) || 20559
     end
 
     def current_dir_pow_name


### PR DESCRIPTION
If POW_HTTP_PORT is defined in ~/.powconfig, use it instead.

Rationale:
Some users may not want the default firewall rule to redirect all port 80 requests to 20559 and may have changed POW_DST_PORT to another value other than port 80.

To support this use-case, config and status tasks should query the pow httpServer directly instead.
