### PR TITLE
prepend newline to rdebug.rb require

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -475,7 +475,7 @@ module Powder
             create_file rails_initializer, get_gist(1135055)
           else
             create_file rack_initializer, get_gist(1262647)
-            append_to_file 'config.ru', "require 'rdebug.rb'"
+            append_to_file 'config.ru', "\nrequire 'rdebug.rb'"
           end
           restart
         else


### PR DESCRIPTION
powder debug setup adds a line to config.ru. If the current contents of your config.ru doesn't end in a newline, config.ru gets broken. This prepends a newline to the added line to avoid that.
