### PR TITLE
Added a new option evn_rvm

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -354,7 +354,7 @@ module Powder
         say %x{rvm env . -- --env >> .powenv}
         show_env
       else
-        say ".rvmrc is not exists."
+        say ".rvmrc does not exist."
       end
     end
 


### PR DESCRIPTION
Added a new option env_rvm.

I commonly type `rrvm env . -- --env > .powenv` to specify rvm gemset path for Pow.
See also http://stackoverflow.com/questions/10154928/pow-rvm-and-zsh-not-working-together

Thank you.
