### PR TITLE
Expanding the 'Pow is not installed' message.

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -124,7 +124,7 @@ module Powder
         FileUtils.ln_s(current_path, symlink_path) unless File.exists?(symlink_path)
         say "Your application is now available at http://#{name}.#{domain}/"
       else
-        say "Pow is not installed."
+        say "Pow is not installed. That is, the ${HOME}/.pow symlink does not exist."
       end
     end
 


### PR DESCRIPTION
I was having a heck of a time trying to figure out why I could run the `pow` command but powder was telling me "Pow is not installed." Hope to make things a little more clear with this.
