### PR TITLE
powder restart does not need to check if powable

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -148,7 +148,6 @@ module Powder
 
     desc "restart", "Restart current pow"
     def restart
-      return unless is_powable?
       FileUtils.mkdir_p('tmp')
       %x{touch tmp/restart.txt}
     end


### PR DESCRIPTION
Minor change:

I think we don't need to check `is_powable?` when issue a `powder restart` command.
We should restart the pow server in any directory.
