### PR TITLE
aliases on link force, link no config and open xip

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -107,8 +107,8 @@ module Powder
     alias :stop :down
 
     desc "link", "Link a pow"
-    method_option :force, :type => :boolean, :default => false, :alias => '-f', :desc => "remove the old configuration, overwrite .powder"
-    method_option :"no-config", :type => :boolean, :default => false, :alias => '-n', :desc => "do not write a .powder file"
+    method_option :force, :type => :boolean, :default => false, :aliases => '-f', :desc => "remove the old configuration, overwrite .powder"
+    method_option :"no-config", :type => :boolean, :default => false, :aliases => '-n', :desc => "do not write a .powder file"
     def link(name=nil)
       return unless is_powable?
       if File.symlink?(POW_PATH)
@@ -183,7 +183,7 @@ module Powder
 
     desc "open", "Open a pow in the browser"
     method_option :browser, :type => :string, :default => false, :aliases => '-b', :desc => 'browser to open with'
-    method_option :xip, :type => :boolean, :default => false, :alias => '-x', :desc => "open xip.io instead of .domain"
+    method_option :xip, :type => :boolean, :default => false, :aliases => '-x', :desc => "open xip.io instead of .domain"
     def open(name=nil)
       browser = options.browser? ? "-a \'#{options.browser}\'" : nil
       if options.xip?


### PR DESCRIPTION
Further options didn't work for me like they should:

powder link -f
powder link -n
powder -o -f

I changed the key "alias" to "aliases" on them and now they work.

There is a possibility there might be a same mistake on 'port PORTMAP'.
