### PR TITLE
Remove get_gist duplication

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -455,12 +455,7 @@ module Powder
       elsif legacy = (is_rails2_app? || is_radiant_app?)
         say "This appears to be a #{legacy} application. You need a config.ru file."
         if yes? "Do you want to autogenerate a basic config.ru for #{legacy}?"
-          uri = URI.parse("https://gist.github.com/raw/909308")
-          http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-          request = Net::HTTP::Get.new(uri.request_uri)
-          create_file "config.ru",  http.request(request).body
+          create_file "config.ru",  get_gist(909308)
           return true
         else
           say "Did not create config.ru"


### PR DESCRIPTION
As noted in #89, the logic for fetching a gist has been present twice.
