### PR TITLE
list: handle non-symlink dirs and URLs in POW_PATH

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -173,12 +173,27 @@ module Powder
 
     desc "list", "List current pows"
     def list
-      pows = Dir[POW_PATH + "/*"].map do |link_or_port|
-        app_origin = get_app_origin(link_or_port)
-        canonical_pwd = canonicalize_path(Dir.pwd)
-        app_is_current = (app_origin == canonical_pwd ? '*' : ' ')
+      pows = Dir[POW_PATH + "/*"].map do |app_pow_path|
+        app_origin = get_app_origin(app_pow_path)
+
+        if File.directory? app_pow_path
+          absolute_pwd = File.realpath(Dir.pwd)
+          app_current = '*' if absolute_pwd == File.realpath(app_pow_path)
+
+          # check id origin of ./public is a symlink, as requested in issue #84
+          # (perhaps of use when serving static files as described in
+          # http://pow.cx/manual.html#section_2.4 )
+          app_public_path = app_pow_path + File::Separator + "public"
+          if File.symlink? app_public_path
+            app_public_origin = canonicalize_path(app_public_path)
+            app_current = 'P' if absolute_pwd == File.realpath(app_public_path)
+            app_origin += " (with ./public -> #{app_public_origin})"
+          end
+        end
+
         unless app_origin.nil?
-          [app_is_current, File.basename(link_or_port), app_origin]
+          app_current ||= ' '
+          [app_current, File.basename(app_pow_path), app_origin]
         else
           nil #don't include unknowns (e.g. non-port, non-url plain files)
         end

--- a/bin/powder
+++ b/bin/powder
@@ -174,11 +174,16 @@ module Powder
     desc "list", "List current pows"
     def list
       pows = Dir[POW_PATH + "/*"].map do |link_or_port|
-        realpath_or_port = get_app_origin(link_or_port)
-        app_is_current = (realpath_or_port == Dir.pwd) ? '*' : ' '
-        [app_is_current, File.basename(link_or_port), realpath_or_port.gsub(ENV['HOME'], '~')]
+        app_origin = get_app_origin(link_or_port)
+        canonical_pwd = canonicalize_path(Dir.pwd)
+        app_is_current = (app_origin == canonical_pwd ? '*' : ' ')
+        unless app_origin.nil?
+          [app_is_current, File.basename(link_or_port), app_origin]
+        else
+          nil #don't include unknowns (e.g. non-port, non-url plain files)
+        end
       end
-      print_table(pows)
+      print_table(pows.compact)
     end
 
     desc "open", "Open a pow in the browser"

--- a/lib/powder.rb
+++ b/lib/powder.rb
@@ -5,10 +5,6 @@ module Powder
   # Mostly follows logic of pow configuration class last changed 2011-08-05,
   # which remains current as of pow v0.4.1 (and master on 2014-01-08)
   # http://github.com/37signals/pow/blob/36b91fe/lib/configuration.js#L161-L188
-  #
-  # Also indicates origin of ./public if a symlink, as requested in issue #84
-  # (perhaps of use when serving static files as described in
-  # http://pow.cx/manual.html#section_2.4 )
   def get_app_origin(app_link)
     case (File.stat(app_link).ftype)
     when "file"
@@ -21,16 +17,13 @@ module Powder
         nil
       end
     when "directory"
-      app_pubdir = app_link + File::Separator + "public"
-      public_note = (File.symlink? app_pubdir ?
-                       " (with /public -> #{canonicalize_path(app_pubdir)})"
-                     : "" )
-      canonicalize_path(app_link) + public_note
+      canonicalize_path(app_link)
     else
       nil
     end
   end
 
+  # Prepare path to the level of accuracy we prefer for list display
   def canonicalize_path(path)
       path = File.readlink path if File.symlink? path
       path.sub(ENV['HOME'], '~')

--- a/lib/powder.rb
+++ b/lib/powder.rb
@@ -1,12 +1,30 @@
 module Powder
   # Get the origin of the application link, whether it's a link to a
-  # rack app or proxy to a port.
+  # rack app, proxy to a port, or proxy to a URL.
+  #
+  # Mostly follows logic of pow configuration class last changed 2011-08-05,
+  # which remains current as of pow v0.4.1 (and master on 2014-01-08)
+  # http://github.com/37signals/pow/blob/36b91fe/lib/configuration.js#L161-L188
   def get_app_origin(app_link)
-    if File.symlink? app_link
-      File.readlink(app_link)
+    case (File.stat(app_link).ftype)
+    when "file"
+      data = File.read(app_link)
+      if data.length < 10 && data.to_i != 0
+        "proxy port: #{data}"
+      elsif url_match = (data.match %r{https?://\S+})
+        "proxy URL: #{url_match.to_s}"
+      else
+        nil
+      end
+    when "directory"
+      canonicalize_path(app_link)
     else
-      port = File.readlines(app_link)[0]
-      "proxy port: #{port}"
+      nil
     end
+  end
+
+  def canonicalize_path(path)
+      path = File.readlink path if File.symlink? path
+      path.sub(ENV['HOME'], '~')
   end
 end

--- a/lib/powder.rb
+++ b/lib/powder.rb
@@ -5,6 +5,10 @@ module Powder
   # Mostly follows logic of pow configuration class last changed 2011-08-05,
   # which remains current as of pow v0.4.1 (and master on 2014-01-08)
   # http://github.com/37signals/pow/blob/36b91fe/lib/configuration.js#L161-L188
+  #
+  # Also indicates origin of ./public if a symlink, as requested in issue #84
+  # (perhaps of use when serving static files as described in
+  # http://pow.cx/manual.html#section_2.4 )
   def get_app_origin(app_link)
     case (File.stat(app_link).ftype)
     when "file"
@@ -17,7 +21,11 @@ module Powder
         nil
       end
     when "directory"
-      canonicalize_path(app_link)
+      app_pubdir = app_link + File::Separator + "public"
+      public_note = (File.symlink? app_pubdir ?
+                       " (with /public -> #{canonicalize_path(app_pubdir)})"
+                     : "" )
+      canonicalize_path(app_link) + public_note
     else
       nil
     end


### PR DESCRIPTION
Changes helper method get_app_origin to conform much closer to the logic
used by pow itself.

In the process, introduces reporting-support for URL proxy files, removes
crashes on encountering non-symlink dirs, and ignores extraneous files
(e.g. badly formatted proxying files or, if they somehow appear, unix
sockets, device files, etc.)

In a seperate second commit, handles #84
