### PR TITLE
Update URL for legacy config.ru file

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -455,7 +455,7 @@ module Powder
       elsif legacy = (is_rails2_app? || is_radiant_app?)
         say "This appears to be a #{legacy} application. You need a config.ru file."
         if yes? "Do you want to autogenerate a basic config.ru for #{legacy}?"
-          uri = URI.parse("https://gist.github.com/raw/909308")
+          uri = URI.parse("https://gist.github.com/sstephenson/909308/raw")
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
The previous gist URL for the legacy config.ru was deprecated, resulting in with the following getting written to config.ru:

``` html
<html><body>You are being <a href="https://github.com/gist/909308">redirected</a>.</body></html>
```
