### PR TITLE
add --external option to open

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -183,6 +183,7 @@ module Powder
     desc "open", "Open a pow in the browser"
     method_option :browser, :type => :string, :default => false, :aliases => '-b', :desc => 'browser to open with'
     method_option :xip, :type => :boolean, :default => false, :alias => '-x', :desc => "open xip.io instead of .domain"
+    method_option :external, :type => :boolean, :default => false, :aliases => '-e', :desc => "open the first external domain"
     def open(name=nil)
       browser = options.browser? ? "-a \'#{options.browser}\'" : nil
       if options.xip?
@@ -197,6 +198,8 @@ module Powder
           Socket.do_not_reverse_lookup = orig
         end
         %x{open #{browser} http://#{name || get_pow_name}.#{local_ip}.xip.io}
+      elsif options.external?
+        %x{open #{browser} http://#{name || get_pow_name}.#{external_domain}}
       else
         %x{open #{browser} http://#{name || get_pow_name}.#{domain}}
       end
@@ -493,6 +496,17 @@ module Powder
       else
         'dev'
       end
+    end
+
+    def external_domain
+      if File.exists? File.expand_path('~/.powconfig')
+        returned_domain = %x{source ~/.powconfig; echo $POW_EXT_DOMAINS}.gsub("\n", "").split(",").first
+        returned_domain = %x{source ~/.powconfig; echo $POW_EXT_DOMAIN}.gsub("\n", "") if returned_domain.nil? || returned_domain.empty?
+        returned_domain = '127.0.0.1.xip.io' if returned_domain.nil? || returned_domain.empty?
+        returned_domain
+      else
+        '127.0.0.1.xip.io'
+      end      
     end
 
     def check_rdebug_initializer

--- a/man/powder.1
+++ b/man/powder.1
@@ -144,6 +144,9 @@ For both forms of link, if the current directory doesn\'t look like an app that 
 \fB$ powder open \-b \'Google Chrome\'\fR => Opens the pow link with browsers with more than one word
 .
 .P
+\fB$ powder open \-\-external \fR => Opens the pow link with the first ext_domain configured in \.powconfig # Also aliased as \-e
+.
+.P
 # Should also works with all the other \'open\' options: \fB$ powder open bacon \-b Safari\fR \fB$ powder open \-\-xip \-b Firefox\fR \fB$ powder \-o \-x \-b \'Google Chrome\'\fR
 .
 .SS "Managing application restarts"

--- a/man/powder.1.html
+++ b/man/powder.1.html
@@ -164,6 +164,10 @@ a basic <strong>config.ru</strong> for Rails 2</p>
 <p>  <code>$ powder open -b 'Google Chrome'</code>
   => Opens the pow link with browsers with more than one word</p>
 
+<p>  <code>$ powder open --external</code>
+  => Opens the pow link with the first ext_domain configured in .powconfig 
+  # Also aliased as -e</p>
+
 <p>  # Should also works with all the other 'open' options:
   <code>$ powder open bacon -b Safari</code>
   <code>$ powder open --xip -b Firefox</code>

--- a/man/powder.1.ronn
+++ b/man/powder.1.ronn
@@ -93,6 +93,10 @@ a basic **config.ru** for Rails 2
   `$ powder open -b 'Google Chrome'`
   => Opens the pow link with browsers with more than one word
 
+  `$ powder open --external` 
+  => Opens the pow link with the first ext_domain configured in .powconfig 
+  # Also aliased as -e
+
   # Should also works with all the other 'open' options:
   `$ powder open bacon -b Safari`
   `$ powder open --xip -b Firefox`


### PR DESCRIPTION
Allow user to use a configured external domain when calling `$ powder open`.

`powder open` currently defaults to the first configured `POW_DOMAIN`, but there is no way to open a configured `POW_EXT_DOMAIN` besides xip.io. This allows a user to configure a different external domain (e.g., one that always resolves to 127.0.0.1), and open the application using powder.

for example, you can add

```
export POW_EXT_DOMAINS=vcap.me,xip.io
```

 to your `.powconfig`, then call `$ powder open -e` to open your app to `my_cool_app.vcap.me`.
