### PR TITLE
fix option browser default nil

### DIFF
--- a/bin/powder
+++ b/bin/powder
@@ -181,10 +181,10 @@ module Powder
     end
 
     desc "open", "Open a pow in the browser"
-    method_option :browser, :type => :string, :default => false, :aliases => '-b', :desc => 'browser to open with'
+    method_option :browser, :type => :string, :default => nil, :aliases => '-b', :desc => 'browser to open with'
     method_option :xip, :type => :boolean, :default => false, :alias => '-x', :desc => "open xip.io instead of .domain"
     def open(name=nil)
-      browser = options.browser? ? "-a \'#{options.browser}\'" : nil
+      browser = options.browser ? "-a \'#{options.browser}\'" : nil
       if options.xip?
         local_ip = '0.0.0.0'
         begin


### PR DESCRIPTION

```
$ powder open
Expected string default value for '--browser'; got false (boolean)
```

on ruby 2.3.3, thor 0.19.4