### PR TITLE
Minor fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org/"
 
 # Specify your gem's dependencies in powder.gemspec
 gemspec

--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ powder manages [pow](http://pow.cx/)
 
     $ powder debug
     => Opens a debug shell with your application environment
-    
+
     $ powder open
     => Opens the pow link in a browser
     # aliased as powder -o
@@ -127,7 +127,7 @@ powder manages [pow](http://pow.cx/)
     # aliased as powder [prod|dev]
     # This is a wrapper for powder env RAILS_ENV ...
 
-    
+
 ### Install and uninstall Pow ###
 
     $ powder install
@@ -147,7 +147,7 @@ powder manages [pow](http://pow.cx/)
     $ powder up
     => Enable Pow
 	# aliased as powder start
-	
+
     $ powder down
     => Disable Pow
 	# aliased as powder stop

--- a/bin/powder
+++ b/bin/powder
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'rubygems'
 require 'thor'

--- a/powder.gemspec
+++ b/powder.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Phil Nash", "Adam Rogers"]
   s.email       = ["no"]
-  s.homepage    = "http://github.com/Rodreegez/powder"
+  s.homepage    = "https://github.com/powder-rb/powder"
   s.summary     = %q{Makes Pow even easier}
   s.description = %q{Makes Pow even easier. I mean really, really, ridiculously easy.}
 


### PR DESCRIPTION
- Use "/usr/bin/env ruby" as the shebang.
- Some minor cleanup.

```
# this is my Mac's system ruby
$ /usr/bin/ruby -v
ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin16]

# this is my rbenv ruby
$ /usr/bin/env ruby -v
ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-darwin16]

$ rbenv global
2.3.3
```