### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/powder.gemspec
+++ b/powder.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/powder-rb/powder"
   s.summary     = %q{Makes Pow even easier}
   s.description = %q{Makes Pow even easier. I mean really, really, ridiculously easy.}
+  s.license     = 'MIT'
 
   s.rubyforge_project = "powder"
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.
