### PR TITLE
Default domain switched to .test due to last pow update

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,7 @@ powder manages [pow](http://pow.cx/)
     # aliased as powder -o -x
 
     $ powder open [bacon]
-    => Opens http://bacon.dev in a browser
+    => Opens http://bacon.test in a browser
     # if you have set up alternative top level domains in .powconfig,
     # then the first listed domain will be opened.
 
@@ -93,7 +93,7 @@ powder manages [pow](http://pow.cx/)
     $ powder -o -x -b 'Google Chrome'
 
     $ powder open [--path|-p] home
-    => Opens the pow link with a path appended, e.g. http://bacon.dev/home
+    => Opens the pow link with a path appended, e.g. http://bacon.test/home
 
     $ powder restart
     => Restart the current app

--- a/bin/powder
+++ b/bin/powder
@@ -498,10 +498,10 @@ module Powder
       if File.exists? File.expand_path('~/.powconfig')
         returned_domain = %x{source ~/.powconfig; echo $POW_DOMAINS}.gsub("\n", "").split(",").first
         returned_domain = %x{source ~/.powconfig; echo $POW_DOMAIN}.gsub("\n", "") if returned_domain.nil? || returned_domain.empty?
-        returned_domain = 'dev' if returned_domain.nil? || returned_domain.empty?
+        returned_domain = 'test' if returned_domain.nil? || returned_domain.empty?
         returned_domain
       else
-        'dev'
+        'test'
       end
     end
 

--- a/man/powder.1
+++ b/man/powder.1
@@ -129,7 +129,7 @@ For both forms of link, if the current directory doesn\'t look like an app that 
 \fB$ powder open [bacon]\fR
 .
 .br
-=> Opens http://bacon\.dev in a browser
+=> Opens http://bacon\.test in a browser
 .
 .br
 # if you have set up alternative top level domains in \.powconfig,
@@ -144,7 +144,7 @@ For both forms of link, if the current directory doesn\'t look like an app that 
 \fB$ powder open \-b \'Google Chrome\'\fR => Opens the pow link with browsers with more than one word
 .
 .P
-\fB$ powder open \-\-path home\fR => Opens the pow link with a path appended (http://bacon.dev/home) # Also aliased as \-p
+\fB$ powder open \-\-path home\fR => Opens the pow link with a path appended (http://bacon.test/home) # Also aliased as \-p
 .
 .P
 # Should also works with all the other \'open\' options: \fB$ powder open bacon \-b Safari\fR \fB$ powder open \-\-xip \-b Firefox\fR \fB$ powder \-o \-x \-b \'Google Chrome\'\fR

--- a/man/powder.1.html
+++ b/man/powder.1.html
@@ -153,7 +153,7 @@ a basic <strong>config.ru</strong> for Rails 2</p>
   # aliased as powder -o</p>
 
 <p>  <code>$ powder open [bacon]</code><br />
-  => Opens http://bacon.dev in a browser<br />
+  => Opens http://bacon.test in a browser<br />
   # if you have set up alternative top level domains in .powconfig,<br />
   # then the first listed domain will be opened.</p>
 
@@ -165,7 +165,7 @@ a basic <strong>config.ru</strong> for Rails 2</p>
   => Opens the pow link with browsers with more than one word</p>
 
 <p>  <code>$ powder open --path home</code>
-  => Opens the pow link with a path appended (http://bacon.dev/home)
+  => Opens the pow link with a path appended (http://bacon.test/home)
   # Also aliased as -p</p>
 
 <p>  # Should also works with all the other 'open' options:

--- a/man/powder.1.ronn
+++ b/man/powder.1.ronn
@@ -82,7 +82,7 @@ a basic **config.ru** for Rails 2
   # aliased as powder -o
 
   `$ powder open [bacon]`  
-  => Opens http://bacon.dev in a browser  
+  => Opens http://bacon.test in a browser
   # if you have set up alternative top level domains in .powconfig,  
   # then the first listed domain will be opened.
 
@@ -94,7 +94,7 @@ a basic **config.ru** for Rails 2
   => Opens the pow link with browsers with more than one word
 
   `$ powder open --path home`
-  => Opens the pow link with a path appended (http://bacon.dev/home)
+  => Opens the pow link with a path appended (http://bacon.test/home)
   # Also aliased as -p
 
   # Should also works with all the other 'open' options:


### PR DESCRIPTION
Google Chrome forces .dev domains to https.

https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/
https://github.com/basecamp/pow/pull/547